### PR TITLE
[BAPL-125]Mnesia stops working when deploy with same version is made

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-erlang 23.2.5
-elixir 1.11.3-otp-23
+erlang 24
+elixir 1.12.1-otp-24

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Mnesia auto clustering made easy!
 
 Docs can be found at [https://hexdocs.pm/mnesiac](https://hexdocs.pm/mnesiac).
 
+**_NOTICE:_** This fork is intended to be used only in projects that are using libcluster
+
 **_NOTICE:_** Mnesiac, while stable, is still considered pre `1.0`. This means the API can, and may, change at any time. Please ensure you review the docs and changelog prior to updating.
 
 **_NOTICE:_** Mnesiac allows a significant amount of freedom with how it behaves. This allows you to customize Mnesiac to suit your needs. However, this also allows for a fair amount of foot gunning. Please ensure you've done your due diligence when using this library, or Mnesia itself for that matter. It isn't a silver bullet, and it shouldn't be treated as one.

--- a/lib/mnesiac/store_manager.ex
+++ b/lib/mnesiac/store_manager.ex
@@ -125,7 +125,7 @@ defmodule Mnesiac.StoreManager do
   This function returns a map of tables and their cookies.
   """
   def get_table_cookies(node \\ node()) do
-    tables = :rpc.call(node, :mnesia, :system_info, [:tables])
+    tables = :rpc.call(node, :mnesia, :system_info, [:local_tables])
 
     Enum.reduce(tables, %{}, fn t, acc ->
       Map.put(acc, t, :rpc.call(node, :mnesia, :table_info, [t, :cookie]))

--- a/lib/mnesiac/supervisor.ex
+++ b/lib/mnesiac/supervisor.ex
@@ -14,7 +14,7 @@ defmodule Mnesiac.Supervisor do
   @impl true
   def init([config, opts]) do
     Logger.info("[mnesiac:#{node()}] mnesiac starting...")
-    Mnesiac.init_mnesia(config)
+    :ok = Mnesiac.init_mnesia(config)
     Logger.info("[mnesiac:#{node()}] mnesiac started")
 
     opts = Keyword.put(opts, :strategy, :one_for_one)

--- a/lib/mnesiac/supervisor.ex
+++ b/lib/mnesiac/supervisor.ex
@@ -13,6 +13,7 @@ defmodule Mnesiac.Supervisor do
 
   @impl true
   def init([config, opts]) do
+    Logger.info("[mnesiac starting with config #{config}]")
     Logger.info("[mnesiac:#{node()}] mnesiac starting...")
     :ok = Mnesiac.init_mnesia(config)
     Logger.info("[mnesiac:#{node()}] mnesiac started")

--- a/lib/mnesiac/supervisor.ex
+++ b/lib/mnesiac/supervisor.ex
@@ -12,9 +12,9 @@ defmodule Mnesiac.Supervisor do
   end
 
   @impl true
-  def init([config, opts]) do
-    Logger.info("[mnesiac starting with config #{config}]")
-    Logger.info("[mnesiac:#{node()}] mnesiac starting...")
+  def init([hosts_fn, opts]) do
+    config = apply(hosts_fn,[])
+    Logger.info("[mnesiac:#{node()}] starting with hosts: #{inspect(config)}")
     :ok = Mnesiac.init_mnesia(config)
     Logger.info("[mnesiac:#{node()}] mnesiac started")
 

--- a/mix.exs
+++ b/mix.exs
@@ -7,7 +7,7 @@ defmodule Mnesiac.MixProject do
     [
       app: :mnesiac,
       version: "0.3.9",
-      elixir: "~> 1.8",
+      elixir: "~> 1.12",
       elixirc_paths: elixirc_paths(Mix.env()),
       test_coverage: [tool: ExCoveralls],
       preferred_cli_env: [


### PR DESCRIPTION
This PR intends to stop errors like `{:aborted, {:no_exists, [...]}}` during deployment
